### PR TITLE
The host header of a HTTP request should include a port part if the port is not default (80)

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -441,7 +441,7 @@ var WebSocket = function(url, proto, opts) {
             var u = urllib.parse(url);
             httpClient = http.createClient(u.port || 80, u.hostname);
             httpPath = (u.pathname || '/') + (u.search || '');
-            httpHeaders.Host = u.hostname;
+            httpHeaders.Host = u.hostname + (u.port ? (":" + u.port) : "");
             break;
 
         case 'ws+unix':


### PR DESCRIPTION
As per http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-12#section-9.4, the host header of a HTTP request should include a port part if the port is not default (80). Therefore, the UPGRADE request host header for connecting to a WS should also include a port part if the port is not default.

Thanks!
