### PR TITLE
Lazily evaluate arguments to debug calls

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -22,6 +22,10 @@ var debug = (debugLevel & 0x4) ?
     function() { sys.error.apply(this, arguments); } :
     function() { };
 
+var debugLazy = (debugLevel & 0x4) ?
+    function(func) { debug(func()); } :
+    function(func) { };
+
 // Generate a Sec-WebSocket-* value
 var createSecretKey = function() {
     // How many spaces will we be inserting?
@@ -223,7 +227,7 @@ var WebSocket = function(url, proto, opts) {
 
         // FRAME_LO
         function(buf, off) {
-            debug('frame_lo(' + sys.inspect(buf) + ', ' + off + ')');
+            debugLazy(function(){return 'frame_lo(' + sys.inspect(buf) + ', ' + off + ')';});
 
             // Find the first instance of 0xff, our terminating byte
             for (var i = off; i < buf.length && buf[i] != 0xff; i++)
@@ -283,7 +287,7 @@ var WebSocket = function(url, proto, opts) {
 
         // FRAME_HI
         function(buf, off) {
-            debug('frame_hi(' + sys.inspect(buf) + ', ' + off + ')');
+            debugLazy(function(){return 'frame_hi(' + sys.inspect(buf) + ', ' + off + ')';});
 
             if (buf[off] !== 0) {
                 throw new Error('High-byte framing not supported.');
@@ -300,7 +304,7 @@ var WebSocket = function(url, proto, opts) {
             return;
         }
 
-        debug('dataListener(' + sys.inspect(buf) + ')');
+        debugLazy(function(){return 'dataListener(' + sys.inspect(buf) + ')';});
 
         var off = 0;
         var consumed = 0;
@@ -441,11 +445,11 @@ var WebSocket = function(url, proto, opts) {
         var key2 = createSecretKey();
         var challenge = createChallenge();
 
-        debug(
+        debugLazy(function(){return 
             'key1=\'' + str2hex(key1) + '\'; ' +
             'key2=\'' + str2hex(key2) + '\'; ' +
-            'challenge=\'' + str2hex(challenge) + '\''
-        );
+            'challenge=\'' + str2hex(challenge) + '\'';
+        });
 
         var httpHeaders = {
             'Connection' : 'Upgrade',
@@ -516,10 +520,10 @@ var WebSocket = function(url, proto, opts) {
 
                         // Handshaking fails; we're donezo
                         if (actual != expected) {
-                            debug(
+                            debugLazy(function(){return 
                                 'expected=\'' + str2hex(expected) + '\'; ' +
-                                'actual=\'' + str2hex(actual) + '\''
-                            );
+                                'actual=\'' + str2hex(actual) + '\'';
+                            });
 
                             process.nextTick(function() {
                                 // N.B. Emit 'wserror' here, as 'error' is a reserved word in the


### PR DESCRIPTION
Switch logging to use debugLazy to lazyly evalaute long running call like sys.inspect(buf).  As per issue #13, this hage a large performance implication (in the good way).
