### PR TITLE
'sys' renamed to 'util' for node 0.6.1 silent warning fix

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -5,7 +5,11 @@ var events = require('events');
 var http = require('http');
 var net = require('net');
 var urllib = require('url');
-var sys = require('sys');
+try{
+    var sys = require('util');
+}catch(e){
+    var sys = require('sys');
+}
 
 var FRAME_NO = 0;
 var FRAME_LO = 1;


### PR DESCRIPTION
just a little silent warning fix.
